### PR TITLE
Changing Dockerfile so that it will run npm install during image creation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,8 @@ RUN cd /usr/src/node-red/node_modules/node-red/nodes/core; \
     awk '{system("mv "$1" "$1".ign")}';
 RUN cd /usr/src/node-red/node_modules;  ls -1 | grep 'node-red-node' | xargs rm -rf
 COPY node_modules /data/node_modules
-USER root:root
+USER root
+RUN chown -R node-red:node-red /data/node_modules
+USER node-red
 RUN cd /data && npm install
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,3 +6,6 @@ RUN cd /usr/src/node-red/node_modules/node-red/nodes/core; \
     awk '{system("mv "$1" "$1".ign")}';
 RUN cd /usr/src/node-red/node_modules;  ls -1 | grep 'node-red-node' | xargs rm -rf
 COPY node_modules /data/node_modules
+USER root:root
+RUN cd /data && npm install
+


### PR DESCRIPTION
This commit adds a few extra lines in Dockerfile so that the image creation will install necessary dependencies (in particular "jsonata", used in 'change' and 'switch' nodes, "nodemailer", used in 'email' node, and "geolib" used in 'geofence' nodes)