### PR TITLE
Adding HTTP POST and e-mail field

### DIFF
--- a/node_modules/node-red-contrib-middleware/nodes/5-httprequest_out.html
+++ b/node_modules/node-red-contrib-middleware/nodes/5-httprequest_out.html
@@ -1,0 +1,209 @@
+<!--
+  Copyright JS Foundation and other contributors, http://js.foundation
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<script type="text/x-red" data-template-name="http request out">
+    <div class="form-row">
+        <label for="node-input-method"><i class="fa fa-tasks"></i> <span data-i18n="httpin.label.method"></span></label>
+        <select type="text" id="node-input-method" style="width:70%;">
+        <option value="GET">GET</option>
+        <option value="POST">POST</option>
+        <option value="PUT">PUT</option>
+        <option value="DELETE">DELETE</option>
+        <option value="use" data-i18n="httpin.setby"></option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-url"><i class="fa fa-globe"></i> <span data-i18n="httpin.label.url"></span></label>
+        <input id="node-input-url" type="text" placeholder="http://">
+    </div>
+
+    <div class="form-row">
+        <input type="checkbox" id="node-input-usetls" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-usetls" style="width: auto" data-i18n="httpin.use-tls"></label>
+        <div id="node-row-tls" class="hide">
+            <label style="width: auto; margin-left: 20px; margin-right: 10px;" for="node-input-tls"><span data-i18n="httpin.tls-config"></span></label><input type="text" style="width: 300px" id="node-input-tls">
+        </div>
+    </div>
+
+    <div class="form-row">
+        <input type="checkbox" id="node-input-useAuth" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-useAuth" style="width: 70%;"><span data-i18n="httpin.basicauth"></span></label>
+        <div style="margin-left: 20px" class="node-input-useAuth-row hide">
+            <div class="form-row">
+                <label for="node-input-user"><i class="fa fa-user"></i> <span data-i18n="common.label.username"></span></label>
+                <input type="text" id="node-input-user">
+            </div>
+            <div class="form-row">
+                <label for="node-input-password"><i class="fa fa-lock"></i> <span data-i18n="common.label.password"></span></label>
+                <input type="password" id="node-input-password">
+            </div>
+        </div>
+    </div>
+    <div class="form-row">
+      <label for="node-input-body"><i class="fa fa-envelope"></i> <span data-i18n="httpin.label.body"></span></label>
+      <input type="text" id="node-input-body" placeholder="Message body">
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-ret"><i class="fa fa-arrow-left"></i> <span data-i18n="httpin.label.return"></span></label>
+        <select type="text" id="node-input-ret" style="width:70%;">
+        <option value="txt" data-i18n="httpin.utf8"></opti  on>
+        <option value="bin" data-i18n="httpin.binary"></option>
+        <option value="obj" data-i18n="httpin.json"></option>
+        </select>
+    </div>
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="httpin.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]httpin.label.name">
+    </div>
+    <div class="form-tips" id="tip-json" hidden><span data-i18n="httpin.tip.req"></span></div>
+</script>
+
+<script type="text/x-red" data-help-name="http request out">
+    <p>Sends HTTP requests and returns the response.</p>
+
+    <h3>Inputs</h3>
+    <dl class="message-properties">
+        <dt class="optional">url <span class="property-type">string</span></dt>
+        <dd>If not configured in the node, this optional property sets the url of the request.</dd>
+        <dt class="optional">method <span class="property-type">string</span></dt>
+        <dd>If not configured in the node, this optional property sets the HTTP method of the request.
+            Must be one of <code>GET</code>, <code>PUT</code>, <code>POST</code>, <code>PATCH</code> or <code>DELETE</code>.</dd>
+        <dt class="optional">headers <span class="property-type">object</span></dt>
+        <dd>Sets the HTTP headers of the request.</dd>
+        <dt class="optional">cookies <span class="property-type">object</span></dt>
+        <dd>If set, can be used to send cookies with the request.</dd>
+        <dt class="optional">payload</dt>
+        <dd>Sent as the body of the request.</dd>
+    </dl>
+    <h3>Outputs</h3>
+    <dl class="message-properties">
+        <dt>payload <span class="property-type">string | object | buffer</span></dt>
+        <dd>The body of the response. The node can be configured to return the body
+             as a string, attempt to parse it as a JSON string or leave it as a
+             binary buffer.</dd>
+        <dt>statusCode <span class="property-type">number</span></dt>
+        <dd>The status code of the response, or the error code if the request could not be completed.</dd>
+        <dt>headers <span class="property-type">object</span></dt>
+        <dd>An object containing the response headers.</dd>
+        <dt>responseUrl <span class="property-type">string</span></dt>
+        <dd>In case any redirects occurred while processing the request, this property is the final redirected url.
+            Otherwise, the url of the original request.</dd>
+        <dt>responseCookies <span class="property-type">object</span></dt>
+        <dd>If the response includes cookies, this propery is an object of name/value pairs for each cookie.</dd>
+    </dl>
+    <h3>Details</h3>
+    <p>When configured within the node, the URL property can contain <a href="http://mustache.github.io/mustache.5.html" target="_blank">mustache-style</a> tags. These allow the
+    url to be constructed using values of the incoming message. For example, if the url is set to
+    <code>example.com/{{{topic}}}</code>, it will have the value of <code>msg.topic</code> automatically inserted.
+    Using {{{...}}} prevents mustache from escaping characters like / & etc.</p>
+    <p><b>Note</b>: If running behind a proxy, the standard <code>http_proxy=...</code> environment variable should be set and Node-RED restarted.</p>
+    <h4>Using multiple HTTP Request nodes</h4>
+    <p>In order to use more than one of these nodes in the same flow, care must be taken with
+    the <code>msg.headers</code> property. The first node will set this property with
+    the response headers. The next node will then use those headers for its request - this
+    is not usually the right thing to do. If <code>msg.headers</code> property is left unchanged
+    between nodes, it will be ignored by the second node. To set custom headers, <code>msg.headers</code>
+    should first be deleted or reset to an empty object: `{}`.
+    <h4>Cookie handling</h4>
+    <p>The <code>cookies</code> property passed to the node must be an object of name/value pairs.
+    The value can be either a string to set the value of the cookie or it can be an
+    object with a single <code>value</code> property.<p>
+    <p>Any cookies returned by the request are passed back under the <code>responseCookies</code> property.</p>
+    <h4>Content type handling</h4>
+    <p>If <code>msg.payload</code> is an Object, the node will automatically set the content type
+    of the request to <code>application/json</code> and encode the body as such.</p>
+    <p>To encode the request as form data, <code>msg.headers["content-type"]</code> should be set to <code>application/x-www-form-urlencoded</code>.</p>
+
+</script>
+
+<script type="text/javascript">
+    RED.nodes.registerType('http request out',{
+        category: 'output',
+        color:"rgb(231, 231, 174)",
+        defaults: {
+            name: {value:""},
+            method:{value:"GET"},
+            ret: {value:"txt"},
+            body: {value:""},
+            url:{value:"",validate:function(v) { return (v.trim().length === 0) || (v.indexOf("://") === -1) || (v.trim().indexOf("http") === 0)} },
+            tls: {type:"tls-config",required: false}
+        },
+        credentials: {
+            user: {type:"text"},
+            password: {type: "password"}
+        },
+        inputs:1,
+        outputs:0,
+        outputLabels: function(i) {
+            return ({txt:"UTF8 string", bin:"binary buffer", obj:"parsed JSON object"}[this.ret]);
+        },
+        icon: "white-globe.png",
+        label: function() {
+            return this.name||this._("httpin.httpreq");
+        },
+        labelStyle: function() {
+            return this.name?"node_label_italic":"";
+        },
+        oneditprepare: function() {
+            $("#node-input-useAuth").change(function() {
+                if ($(this).is(":checked")) {
+                    $(".node-input-useAuth-row").show();
+                } else {
+                    $(".node-input-useAuth-row").hide();
+                    $('#node-input-user').val('');
+                    $('#node-input-password').val('');
+                }
+            });
+            if (this.credentials.user || this.credentials.has_password) {
+                $('#node-input-useAuth').prop('checked', true);
+            } else {
+                $('#node-input-useAuth').prop('checked', false);
+            }
+            $("#node-input-useAuth").change();
+
+            function updateTLSOptions() {
+                if ($("#node-input-usetls").is(':checked')) {
+                    $("#node-row-tls").show();
+                } else {
+                    $("#node-row-tls").hide();
+                }
+            }
+            if (this.tls) {
+                $('#node-input-usetls').prop('checked', true);
+            } else {
+                $('#node-input-usetls').prop('checked', false);
+            }
+            updateTLSOptions();
+            $("#node-input-usetls").on("click",function() {
+                updateTLSOptions();
+            });
+            $("#node-input-ret").change(function() {
+                if ($("#node-input-ret").val() === "obj") {
+                    $("#tip-json").show();
+                } else {
+                    $("#tip-json").hide();
+                }
+            });
+            $("#node-input-body").typedInput({default:'msg',types:['msg']});
+        },
+        oneditsave: function() {
+            if (!$("#node-input-usetls").is(':checked')) {
+                $("#node-input-tls").val("_ADD_");
+            }
+        }
+    });
+</script>

--- a/node_modules/node-red-contrib-middleware/nodes/5-httprequest_out.js
+++ b/node_modules/node-red-contrib-middleware/nodes/5-httprequest_out.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright JS Foundation and other contributors, http://js.foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+module.exports = function(RED) {
+    "use strict";
+
+    function HTTPRequestOut(n) {
+        RED.nodes.createNode(this,n);
+    }
+
+    RED.nodes.registerType("http request out",HTTPRequestOut);
+}

--- a/node_modules/node-red-contrib-middleware/nodes/locales/en-US/5-httprequest_out.json
+++ b/node_modules/node-red-contrib-middleware/nodes/locales/en-US/5-httprequest_out.json
@@ -1,0 +1,41 @@
+{
+  "httpin": {
+    "label": {
+        "method": "Method",
+        "url": "URL",
+        "doc": "Docs",
+        "return": "Return",
+        "upload": "Accept file uploads?",
+        "status": "Status code",
+        "headers": "Headers",
+        "other": "other",
+        "body": "Request body",
+        "name": "Name"
+    },
+    "setby": "- set by msg.method -",
+    "basicauth": "Use basic authentication",
+    "use-tls": "Enable secure (SSL/TLS) connection",
+    "tls-config":"TLS Configuration",
+    "utf8": "a UTF-8 string",
+    "binary": "a binary buffer",
+    "json": "a parsed JSON object",
+    "tip": {
+        "in": "The url will be relative to ",
+        "res": "The messages sent to this node <b>must</b> originate from an <i>http input</i> node",
+        "req": "Tip: If the JSON parse fails the fetched string is returned as-is."
+    },
+    "httpreq": "http request",
+    "errors": {
+        "not-created": "Cannot create http-in node when httpNodeRoot set to false",
+        "missing-path": "missing path",
+        "no-response": "No response object",
+        "json-error": "JSON parse error",
+        "no-url": "No url specified",
+        "deprecated-call":"Deprecated call to __method__",
+        "invalid-transport":"non-http transport requested"
+    },
+    "status": {
+        "requesting": "requesting"
+    }
+  }
+}

--- a/node_modules/node-red-contrib-middleware/package.json
+++ b/node_modules/node-red-contrib-middleware/package.json
@@ -12,7 +12,8 @@
   "node-red": {
     "nodes": {
       "device": "nodes/3-device.js",
-      "edgedetection": "nodes/4-edgedetection.js"
+      "edgedetection": "nodes/4-edgedetection.js",
+      "httprequest_out": "nodes/5-httprequest_out.js"
     }
   }
 }

--- a/node_modules/node-red-node-email/61-email.html
+++ b/node_modules/node-red-node-email/61-email.html
@@ -42,6 +42,10 @@
         <input type="text" id="node-input-subject" placeholder="Message title">
     </div>
     <div class="form-row">
+        <label for="node-input-body"><i class="fa fa-envelope"></i> <span data-i18n="email.label.body"></span></label>
+        <input type="text" id="node-input-body" placeholder="Message body">
+    </div>
+    <div class="form-row">
         <label for="node-input-port"><i class="fa fa-random"></i> <span data-i18n="email.label.port"></span></label>
         <input type="text" id="node-input-port" placeholder="465" style="width:100px">
         <label style="width:40px"> </label>
@@ -84,7 +88,8 @@
             dname: {value:""},
             to: {required: true},
             from: {required: true},
-            subject: {required: true}
+            subject: {required: true},
+            body : {required: true}
         },
         // credentials: {
         //     userid: {type:"text"},
@@ -100,6 +105,9 @@
         },
         labelStyle: function() {
             return (this.dname||!this.topic)?"node_label_italic":"";
+        },
+        oneditprepare: function() {
+          $("#node-input-body").typedInput({default:'msg',types:['msg']});
         }
     });
 })();

--- a/node_modules/node-red-node-email/locales/en-US/61-email.json
+++ b/node_modules/node-red-node-email/locales/en-US/61-email.json
@@ -13,7 +13,8 @@
             "folder": "Folder",
             "protocol": "Protocol",
             "useSSL": "Use SSL?",
-            "disposition": "Disposition"
+            "disposition": "Disposition",
+            "body" : "Body"
         },
         "default-message": "__description__\n\nFile from Node-RED is attached: __filename__",
         "tip": {


### PR DESCRIPTION
This PR adds a new node - HTTP POST - so that POST requests can be sent to an endpoint. It works just like output devices, but the recipient is a HTTP endpoint. 

This PR also adds a field to the e-mail node, selecting which "variable" will be used to represent the e-mail body. Also, just like output device node.